### PR TITLE
Fix automatic release notes generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.request(`POST /repos/${{ github.repository }}/releases`, {
-              tag_name: ${{ steps.extract_version.outputs.version }},
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo, 
+              tag_name: "${{ steps.extract_version.outputs.version }}",
               generate_release_notes: true
             });


### PR DESCRIPTION
Since the `script` parameter is JavaScript, the value of the `tag_name` had to be wrapped in quotes in order to be interpreted as a `String`. Otherwise the action takes it as a JS variable 🤦🏼 .