### PR TITLE
Add selector for kubernetes context in the settings page

### DIFF
--- a/ui/src/clients/backend.ts
+++ b/ui/src/clients/backend.ts
@@ -5,7 +5,7 @@ import { Buffer } from 'buffer'
 
 function configuration() {
   const configuration = new Configuration()
-  configuration.basePath = 'https://api.apps.rancher.io'
+  configuration.basePath = import.meta.env.PROD ? 'https://api.apps.rancher.io' : 'http://localhost:3000/api'
 
   return configuration
 }

--- a/ui/src/clients/kubectl.ts
+++ b/ui/src/clients/kubectl.ts
@@ -59,3 +59,36 @@ export async function getServices(ddClient: DockerDesktopClient, selectors: { ke
       })
   })
 }
+
+export async function getContexts(ddClient: DockerDesktopClient): Promise<{ name: string, selected?: boolean }[]> {
+  return new Promise<{ name: string, selected?: boolean }[]>((resolve, reject) => {
+    ddClient.extension.host?.cli.exec('kubectl', [
+      'config', 'current-context'
+    ])
+      .then(currentContextResult => {
+        const selectedContext: string = currentContextResult.stdout.replace('\n', '')
+        ddClient.extension.host?.cli.exec('kubectl', [
+          'config', 'get-contexts',
+          '-o', 'name'
+        ])
+          .then(contextsResult => {
+            const contexts: string[] = contextsResult?.stdout.split('\n')
+            resolve(contexts.slice(0, contexts.length - 1).map(name => { return { name, selected: name == selectedContext } }))
+          })
+          .catch((e) => {
+            console.error('Unexpected error getting k8s contexts', e)
+            reject('Unexpected error reading kubernetes contexts')
+          })
+      })
+      .catch((e) => {
+        console.error('Unexpected error getting current k8s context', e)
+        reject('Unexpected error reading current kubernetes context')
+      })
+  })
+}
+
+export async function useContext(ddClient: DockerDesktopClient, context: string): Promise<void> {
+  await ddClient.extension.host?.cli.exec('kubectl', [
+    'config', 'use-context', context
+  ])
+}

--- a/ui/src/pages/SettingsPage/index.tsx
+++ b/ui/src/pages/SettingsPage/index.tsx
@@ -14,7 +14,7 @@ export default function SettingsPage() {
       <Typography variant='h5' sx={ { mb: 3 } }>Used to navigate and install the collection</Typography>
       <AuthenticationForm />
       <Typography variant='h3' sx={ { mt: 3 } }>Kubernetes</Typography>
-      <Typography variant='h5' sx={ { mb: 3 } }>Configure the k8s clsuter where workloads will be installed</Typography>
+      <Typography variant='h5' sx={ { mb: 3 } }>Configure the cluster where workloads will be installed</Typography>
       <K8sContextForm />
     </>
   )

--- a/ui/src/pages/SettingsPage/index.tsx
+++ b/ui/src/pages/SettingsPage/index.tsx
@@ -1,5 +1,11 @@
-import { Typography } from '@mui/material'
+import { CircularProgress, FormControl, InputLabel, MenuItem, Select, Stack, Typography } from '@mui/material'
 import AuthenticationForm from './components/AuthenticationForm'
+import { useEffect, useState } from 'react'
+import { getContexts, useContext } from '../../clients/kubectl'
+import { createDockerDesktopClient } from '@docker/extension-api-client'
+import { useSnackbar } from 'notistack'
+
+const ddClient = createDockerDesktopClient()
 
 export default function SettingsPage() {
   return (
@@ -7,6 +13,57 @@ export default function SettingsPage() {
       <Typography variant='h3'>Authentication</Typography>
       <Typography variant='h5' sx={ { mb: 3 } }>Used to navigate and install the collection</Typography>
       <AuthenticationForm />
+      <Typography variant='h3' sx={ { mt: 3 } }>Kubernetes</Typography>
+      <Typography variant='h5' sx={ { mb: 3 } }>Configure the k8s clsuter where workloads will be installed</Typography>
+      <K8sContextForm />
     </>
+  )
+}
+
+function K8sContextForm() {
+  const [ state, setState ] = useState<'loading' | 'ready'>()
+  const [ contexts, setContexts ] = useState<{ name: string, selected?: boolean }[]>([])
+  const { enqueueSnackbar } = useSnackbar()
+
+  useEffect(() => {
+    setState('loading')
+    getContexts(ddClient)
+      .then(newContexts => setContexts(newContexts))
+      .catch(error => enqueueSnackbar(error, { autoHideDuration: 5000, key: 'snackbar-k8s-get-contexts' }))
+      .finally(() => setState('ready'))
+  }, [])
+
+  function switchContext(newContext: string) {
+    setState('loading')
+    useContext(ddClient, newContext)
+      .then(() => setContexts(contexts.map(ctx => { return { name: ctx.name, selected: ctx.name === newContext } })))
+      .catch(error => enqueueSnackbar(error, { autoHideDuration: 5000, key: 'snackbar-k8s-use-context' }))
+      .finally(() => setState('ready'))
+  }
+
+  return (
+    <Stack direction='row' alignItems='center' spacing={ 3 }>
+      <FormControl 
+        fullWidth 
+        disabled={ state === 'loading' }
+        size='small'
+        sx={ { maxWidth: '50%' } } >
+        <InputLabel id='k8s-context-label'>Context</InputLabel>
+        <Select
+          labelId='k8s-context-label'
+          id='k8s-context'
+          value={ contexts.find(ctx => ctx.selected)?.name || '' }
+          label='Context'
+          onChange={ e => switchContext(e.target.value) }>
+          { contexts.map((ctx, i) => 
+            <MenuItem 
+              key={ `k8s-context-${i}` } 
+              value={ ctx.name }>
+              { ctx.name }
+            </MenuItem>) }
+        </Select>
+      </FormControl>
+      { state === 'loading' && <CircularProgress size={ 21 } /> }
+    </Stack>
   )
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/38b12cae-e581-42d2-93f2-97067195cf8f)

This selector makes easier to switch between kubernetes contexts for those scenarios where users have more than one. Being able to switch from contexts easily is key because:

* The local development environment may not be able to reach the workloads of a given context
* The currently selected context may not be prepared to work with the desktop tool (`rancher-desktop` context doesn't work out of the box with DD, and the same with `docker-desktop` and RD)