### PR TITLE
Use target arch for helm/kubectl binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,24 @@
 FROM registry.suse.com/bci/bci-base:15.6 AS fetcher
 
+ARG TARGETARCH
 ENV BINS_DIR=/tmp/binaries/darwin
 ENV HELM_VERSION=3.12.2
 ENV KUBECTL_VERSION=1.29.3
 
 RUN mkdir -p ${BINS_DIR}
-RUN curl -s -o helm-v${HELM_VERSION}-darwin-arm64.tar.gz https://get.helm.sh/helm-v${HELM_VERSION}-darwin-arm64.tar.gz \
-    && tar -zxvf helm-v${HELM_VERSION}-darwin-arm64.tar.gz \
-    && mv darwin-arm64/helm ${BINS_DIR}/helm \
-    && curl -LO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/darwin/arm64/kubectl" \
+RUN curl -s -o helm-v${HELM_VERSION}-darwin-${TARGETARCH}.tar.gz https://get.helm.sh/helm-v${HELM_VERSION}-darwin-${TARGETARCH}.tar.gz \
+    && tar -zxvf helm-v${HELM_VERSION}-darwin-${TARGETARCH}.tar.gz \
+    && mv darwin-${TARGETARCH}/helm ${BINS_DIR}/helm \
+    && curl -LO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/darwin/${TARGETARCH}/kubectl" \
     && chmod +x ./kubectl \
     && mv kubectl ${BINS_DIR}/kubectl
 
 ENV BINS_DIR=/tmp/binaries/linux
 RUN mkdir -p ${BINS_DIR}
-RUN curl -s -o helm-v${HELM_VERSION}-linux-amd64.tar.gz https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
-    && tar -zxvf helm-v${HELM_VERSION}-linux-amd64.tar.gz \
-    && mv linux-amd64/helm ${BINS_DIR}/helm \
-    && curl -LO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+RUN curl -s -o helm-v${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://get.helm.sh/helm-v${HELM_VERSION}-linux-${TARGETARCH}.tar.gz \
+    && tar -zxvf helm-v${HELM_VERSION}-linux-${TARGETARCH}.tar.gz \
+    && mv linux-${TARGETARCH}/helm ${BINS_DIR}/helm \
+    && curl -LO "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
     && chmod +x ./kubectl \
     && mv kubectl ${BINS_DIR}/kubectl
 


### PR DESCRIPTION
It appears that the arm64 images still bundle an amd64 `/usr/bin/helm` / `/usr/bin/kubectl`; this means that those executables need to be run under emulation (either qemu, or Rosetta on macOS/VZ).  This PR makes it download the platform-native executable instead, whichever that is.

This is causing a crash in Rancher Desktop due to https://gitlab.com/qemu-project/qemu/-/issues/2560 (filed as https://github.com/rancher-sandbox/rancher-desktop/issues/8606 which we'll deal with separately).  In the mean time, using platform-native executables so that emulation is not needed seemed like the right thing to do in general.

Since arm64 Windows binaries are not available, that is still configured to always use amd64 binaries.

See https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope for how `${TARGETARCH}` is defined.  Please make sure that OBS supports this before merging; I have only tested by building locally.

---

**Extension version**: 0.1.0
**Platform**: Rancher Desktop
**Steps to reproduce**:
1. Install the extension on Rancher Desktop, on an Apple Silicon device.
2. Attempt to login in settings.
3. Check the logs of the backend container (where it runs `helm`).

**Relevant logs**:
<details><summary><tt>docker logs rancher_application-collection-extension-docker-desktop-extension-1</tt></summary>

```
Unexpected error logout user runtime: lfstack.push invalid packing: node=0xffff53e103c0 cnt=0x1 packed=0xffff53e103c00001 -> node=0xffffffff53e103c0
fatal error: lfstack.push

runtime stack:
runtime.throw({0x1ff9ad6?, 0x120000c000380430?})
	runtime/panic.go:1047 +0x5d fp=0xffff7b9ffc18 sp=0xffff7b9ffbe8 pc=0x437e5d
runtime.(*lfstack).push(0x2?, 0xffff7b9ffcc8?)
	runtime/lfstack.go:29 +0x125 fp=0xffff7b9ffc58 sp=0xffff7b9ffc18 pc=0x40bee5
runtime.(*spanSetBlockAlloc).free(...)
	runtime/mspanset.go:322
runtime.(*spanSet).reset(0x348af30)
	runtime/mspanset.go:264 +0x87 fp=0xffff7b9ffc88 sp=0xffff7b9ffc58 pc=0x431947
runtime.finishsweep_m()
	runtime/mgcsweep.go:260 +0x9c fp=0xffff7b9ffcc8 sp=0xffff7b9ffc88 pc=0x425cbc
runtime.gcStart.func1()
	runtime/mgc.go:668 +0x17 fp=0xffff7b9ffcd8 sp=0xffff7b9ffcc8 pc=0x4633b7
runtime.systemstack()
	runtime/asm_amd64.s:496 +0x49 fp=0xffff7b9ffce0 sp=0xffff7b9ffcd8 pc=0x469649
```
</details>